### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,6 +1,8 @@
 # https://github.com/actions/starter-workflows/blob/main/ci/cmake-multi-platform.yml
 
 name: CMake CI/CD
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,4 +1,6 @@
 name: Documentation
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,6 @@
 name: pre-commit
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Ogoruwa/clipt/security/code-scanning/5](https://github.com/Ogoruwa/clipt/security/code-scanning/5)

To fix the problem, you should add a `permissions` key to either the root of the workflow or directly under the `CI_CD` job (since there’s only one job, root-level is simplest and ensures coverage for future jobs). The minimal safe starting point is `contents: read`, which is the most restrictive setting compatible with common CI workflows (source checkout and artifact upload). The `permissions` block should be inserted right after the initial workflow `name`, before `on:`. No additional imports or external methods are required; it is a YAML declarative setting only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
