### PR TITLE
Fixes #3: Make memory leak tests run in `cmake` workflow

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -134,16 +134,19 @@ jobs:
         choco: drmemory
 
     - name: Run memory leak tests (Linux)
+      working-directory: ${{steps.strings.outputs.build-output-dir}}
       if: runner.os == 'Linux'
       run: |
         valgrind --leak-check=full --show-leak-kinds=all -s ctest
 
     - name: Run memory leak tests (MacOS)
+      working-directory: ${{steps.strings.outputs.build-output-dir}}
       if: runner.os == 'macOS'
       run: |
         MallocStackLogging=1 leaks -atExit -- ctest
 
     - name: Run memory leak tests (Windows)
+      working-directory: ${{steps.strings.outputs.build-output-dir}}
       if: runner.os == 'Windows'
       run: |
         drmemory -leak_check -ignore_kernel -batch -results_to_stdout -- ctest

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 .vscode/
+.artifacts/
+
 build/
 bin/
 lib/
 install/
+
+.actrc


### PR DESCRIPTION
- Set working directory of tests step to build directory, so `ctest` can run properly

- Add `.gitignore` entries for `act` (github action local runner) files